### PR TITLE
Add linenoiseRemoteRefereshLine

### DIFF
--- a/linenoise.h
+++ b/linenoise.h
@@ -66,6 +66,8 @@ void linenoiseClearScreen(void);
 void linenoiseSetMultiLine(int ml);
 void linenoisePrintKeyCodes(void);
 
+void LinenoiseRemotePrint(const char *line);
+
 #ifdef __cplusplus
 }
 #endif

--- a/linenoise.h
+++ b/linenoise.h
@@ -66,7 +66,7 @@ void linenoiseClearScreen(void);
 void linenoiseSetMultiLine(int ml);
 void linenoisePrintKeyCodes(void);
 
-void LinenoiseRemotePrint(const char *line);
+void linenoiseRemoteRefreshLine();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
When multiple threads print to the console the output can get a bit jumbled, the other threads can call this function in order to refresh the console output and get the prompt back.